### PR TITLE
Avoid errors when using files other than .gs and .html

### DIFF
--- a/content/modal.html
+++ b/content/modal.html
@@ -1,6 +1,7 @@
 <div id="diffModal" class="modal-dialog" tabindex="0" role="dialog" style="left: 274px; top: 180px; display: none;">
   <div class="modal-dialog-title modal-dialog-title-draggable">
     <span class="modal-dialog-title-text">Diff</span>
+    <span class="modal-dialog-title-text">(warning, only .gs and .html files will be synced)</span>
     <span class="github-diff-modal-close modal-dialog-title-close"></span>
   </div>
   <div class="modal-dialog-content">

--- a/src/gas-api.js
+++ b/src/gas-api.js
@@ -11,7 +11,7 @@ function pull(code) {
     }
     const name = match[1];
     const type = match[2];
-    
+
     if (!code.gas[file]) {
       return () => gasCreateFile(name, type)
       .then(() => {
@@ -20,7 +20,8 @@ function pull(code) {
     } else {
       return () => gasUpdateFile(name, code.github[file]);
     }
-  });
+  })
+  .filter(n => n != undefined);
 
   const delete_promises = changed.filter(f => !code.github[f])
   .map((file) => {
@@ -37,7 +38,7 @@ function pull(code) {
     showAlert("Nothing to do", LEVEL_WARN);
     return;
   }
-  
+
   getGasContext()
   .then(() => {
     return Promise.all(update_promises.map(f => f()))


### PR DESCRIPTION
This is to solve the #28 bug. It would be better to hide incompatible files from diff also but it already works as a fast patch.