### PR TITLE
sets baseUrl from data supplied by background.js rather than deriving it

### DIFF
--- a/src/gas-hub.js
+++ b/src/gas-hub.js
@@ -516,11 +516,7 @@ function handleGistCreated() {
 }
 
 function getBaseUrl() {
-  if(context.isBound) {
-    return `https://script.google.com/macros/d/${context.projectId}/gwt/`;
-  } else {
-    return `https://script.google.com/d/${context.id}/gwt/`
-  }
+  return context.gasHeaders["X-GWT-Module-Base"];
 }
 
 function changeModalState(type, toShow) {


### PR DESCRIPTION
fixes #62 