### PR TITLE
gets baseUrl from gasUrl

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.3",
+  "version": "3.3.4",
   "manifest_version": 2,
   "default_locale": "en",
   "name": "__MSG_appName__",

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.2",
+  "version": "3.3.3",
   "manifest_version": 2,
   "default_locale": "en",
   "name": "__MSG_appName__",

--- a/src/gas-hub.js
+++ b/src/gas-hub.js
@@ -516,7 +516,7 @@ function handleGistCreated() {
 }
 
 function getBaseUrl() {
-  return context.gasHeaders["X-GWT-Module-Base"];
+  return context.gasUrl.substring(0, context.gasUrl.indexOf('/gwt/')) + '/gwt/';
 }
 
 function changeModalState(type, toShow) {


### PR DESCRIPTION
should fix #65 #66 #67 
looks like there are some situations where the header I was using previously isn't getting set which could be causing these issues.  This commit uses the gasUrl value which should always be available to this function to work out the correct baseUrl taking into account both bound / non bound behaviour & regular Google accounts / corporate Google Apps domains