### PR TITLE
disables self hosted gitlab support for now

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.1",
+  "version": "4.0.2",
   "manifest_version": 2,
   "default_locale": "en",
   "name": "__MSG_appName__",
@@ -59,7 +59,6 @@
     "storage",
     "declarativeContent",
     "webRequest",
-    "https://gitlab.com/*",
-    "https://*/*"
+    "https://gitlab.com/*"
   ]
 }

--- a/options/options.html
+++ b/options/options.html
@@ -59,7 +59,7 @@
       </div>
         <div class="login-container gitlab-login-container">
           <div class="login-item login-item-basic">
-            <input id="gitlab-url" type="text" value="https://gitlab.com"/>
+            <!--<input id="gitlab-url" type="text" value="https://gitlab.com"/>-->
             <input id="gitlab-email" type="email" placeholder="email"/>
             <p class="label">login with password:</p>
             <input id="gitlab-password" type="password" placeholder="password"/>


### PR DESCRIPTION
fixes #76 

disables custom domains for gitlab until solution for too broad permissions can be found