### PR TITLE
highlight current repo in repos list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.5",
+  "version": "4.0.6",
   "manifest_version": 2,
   "default_locale": "en",
   "name": "__MSG_appName__",

--- a/src/gas-hub.js
+++ b/src/gas-hub.js
@@ -417,6 +417,17 @@ function updateRepo(repos) {
   });
   if (context.repo) {
     $('#scm-bind-repo').text(`Repo: ${context.repo.fullName}`);
+    
+    //highlight current repo in repos list
+    let repoItems = document.getElementsByClassName('scm-item goog-menuitem');
+    for (let i = 0; i < repoItems.length; i++) {
+      let currentItem = repoItems[i];
+      if (context.repo.fullName === currentItem.innerText) {
+         currentItem.style.background = "lightgrey";
+         break;
+      }
+    }
+    
     return context.repo.fullName;
   }
   return null;


### PR DESCRIPTION
Hey! I love this chrome extension, just started using it today, but thought I'd suggest something which I'd like to see in it. My change iterates through the repos items and highlights the current repo in the items list (would also be nice to useful for the _Branch:_ list too). You may think of a better way to do this, but I've tested in chrome and here's the result:

<img width="725" alt="highlight_current_repo" src="https://user-images.githubusercontent.com/4802954/48640702-55b18700-e9cf-11e8-9339-8d167386c4e4.png">

Cheers!